### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+yagf (0.9.3.2-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 04:27:09 +0100
+
 yagf (0.9.3.2-1) unstable; urgency=medium
 
   * Update to stable release 0.9.3.2.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Boris Pek <tehnick@debian.org>
 Build-Depends: aspell, cmake, debhelper (>= 9), libaspell-dev, libqt4-dev
 Homepage: http://symmetrica.net/cuneiform-linux/yagf-en.html
-Vcs-Git: git://github.com/tehnick/yagf-debian.git
+Vcs-Git: https://github.com/tehnick/yagf-debian.git
 Vcs-Browser: https://github.com/tehnick/yagf-debian
 Standards-Version: 3.9.5
 


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
